### PR TITLE
Export functions from gulpfile, add missing dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,76 +10,134 @@
 
 'use strict';
 
-const depcheck = require('depcheck');
-const eslint = require('gulp-eslint');
+const depcheck_lib = require('depcheck');
+const eslint_lib = require('gulp-eslint');
 const fs = require('fs-extra');
 const gulp = require('gulp');
 const mergeStream = require('merge-stream');
 const mocha = require('gulp-mocha');
 const path = require('path');
 const runSeq = require('run-sequence');
-const tslint = require("gulp-tslint");
+const tslint_lib = require("gulp-tslint");
 const typescript = require('gulp-typescript');
 const typings = require('gulp-typings');
 
-const tsProject = typescript.createProject('tsconfig.json');
+function task(name, deps, impl) {
+  if (gulp.hasTask(name)) {
+    throw new Error(
+        `A task with the name ${JSON.stringify(name)} already exists!`);
+  }
+  gulp.task(name, deps, impl);
+}
 
-gulp.task('init', () => gulp.src("./typings.json").pipe(typings()));
+module.exports.init = function() {
+  task('init', () => gulp.src("./typings.json").pipe(typings()));
+}
 
-gulp.task('lint', ['tslint', 'eslint', 'depcheck']);
+module.exports.depcheck = function depcheck(options) {
+  const defaultOptions = {stickyDeps: new Set()};
+  options = Object.assign({}, defaultOptions, options);
 
-gulp.task('build', () =>
-  mergeStream(
-    gulp.src('src/**/*.ts').pipe(typescript(tsProject)),
-    gulp.src(['src/**/*', '!src/**/*.ts'])
-  ).pipe(gulp.dest('lib'))
-);
+  task('depcheck', () => {
+    return new Promise((resolve, reject) => {
+      depcheck_lib(__dirname, {ignoreDirs: []}, resolve);
+    }).then((result) => {
+      const invalidFiles = Object.keys(result.invalidFiles) || [];
+      const invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
 
-gulp.task('clean', (done) => {
-  fs.remove(path.join(__dirname, 'lib'), done);
-});
+      if (invalidJsFiles.length > 0) {
+        console.log('Invalid files:', result.invalidFiles);
+        throw new Error('Invalid files');
+      }
 
-gulp.task('build-all', (done) => {
-  runSeq('clean', 'init', 'lint', 'build', done);
-});
-
-gulp.task('test', ['build'], () =>
-  gulp.src('test/**/*_test.js', {read: false})
-      .pipe(mocha({
-        ui: 'tdd',
-        reporter: 'spec',
-      }))
-);
-
-gulp.task('tslint', () =>
-  gulp.src('src/**/*.ts')
-    .pipe(tslint({
-      configuration: 'tslint.json',
-    }))
-    .pipe(tslint.report('verbose')));
-
-gulp.task('eslint', () =>
-  gulp.src('test/**/*.js')
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError()));
-
-gulp.task('depcheck', () => new Promise((resolve, reject) => {
-  depcheck(__dirname, {ignoreDirs: []}, (result) => {
-    let invalidFiles = Object.keys(result.invalidFiles) || [];
-    let invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
-    if (invalidJsFiles.length > 0) {
-      console.log('Invalid files:', result.invalidFiles);
-      reject(new Error('Invalid files'));
-      return;
-    }
-
-    if (result.dependencies.length) {
-      console.log('Unused dependencies:', unused.dependencies);
-      reject(new Error('Unused dependencies'));
-      return;
-    }
-
-    resolve();
+      const unused = new Set(result.dependencies);
+      for (const falseUnused of options.stickyDeps) {
+        unused.delete(falseUnused);
+      }
+      if (unused.size > 0) {
+        console.log('Unused dependencies:', unused);
+        throw new Error('Unused dependencies');
+      }
+    });
   });
-}));
+}
+
+module.exports.lint = function(options) {
+  module.exports.tslint(options);
+  module.exports.eslint_lib(options);
+  module.exports.depcheck(options);
+  task('lint', ['tslint', 'eslint', 'depcheck']);
+}
+
+module.exports.tslint = function(options) {
+  const defaultOptions = {tsSrcs: gulp.src('src/**/*.ts')};
+  options = Object.assign({}, defaultOptions, options);
+  task('tslint', () =>
+      options.tsSrcs
+        .pipe(tslint_lib({
+          configuration: 'tslint.json',
+        }))
+        .pipe(tslint_lib.report('verbose')));
+}
+
+module.exports.eslint = function(options) {
+  const defaultOptions = {jsSrcs: gulp.src('test/**/*.js')};
+  options = Object.assign({}, defaultOptions, options);
+  task('eslint', () =>
+      options.jsSrcs
+        .pipe(eslint())
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError()));
+}
+
+module.exports.build = function(options) {
+  const defaultOptions = {
+    tsSrcs: gulp.src('src/**/*.ts'),
+    dataSrcs: gulp.src(['src/**/*', '!src/**/*.ts'])
+  };
+  options = Object.assign({}, defaultOptions, options);
+
+  const tsProject = typescript.createProject('tsconfig.json');
+
+  task('build', () =>
+    mergeStream(
+      options.tsSrcs.pipe(typescript(tsProject)),
+      options.dataSrcs
+    ).pipe(gulp.dest('lib'))
+  );
+}
+
+module.exports.clean = function(options) {
+  const defaultOptions = {buildArtifacts: ['lib']};
+  options = Object.assign({}, defaultOptions, options);
+
+  task('clean', () => {
+    for (const buildArtifact of options.buildArtifacts) {
+      fs.removeSync(path.join(__dirname, buildArtifact));
+    }
+  });
+}
+
+
+module.exports.buildAll = function(options) {
+  module.exports.clean(options);
+  module.exports.init(options);
+  module.exports.lint(options);
+  module.exports.build(options);
+
+  task('build-all', (done) => {
+    runSeq('clean', 'init', 'lint', 'build', done);
+  });
+}
+
+module.exports.test = function(options) {
+  module.exports.buildAll(options);
+
+  task('test', ['build'], () =>
+    gulp.src('test/**/*_test.js', {read: false})
+        .pipe(mocha({
+          ui: 'tdd',
+          reporter: 'spec',
+        }))
+  );
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "depcheck": "^0.6.3",
+    "fs-extra": "^0.30.0",
     "gulp-eslint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "gulp-tslint": "^5.0.0",


### PR DESCRIPTION
This way we can reuse as much as possible from this file in our tools projects even before they're ready to import the whole thing at once.
