### PR TITLE
Upgrade to latest versions of dependencies

### DIFF
--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -102,8 +102,9 @@ module.exports.tslint = function(options) {
       options.tsSrcs
         .pipe(tslint_lib({
           configuration: tslintConfig,
+          formatter: 'verbose'
         }))
-        .pipe(tslint_lib.report('verbose')));
+        .pipe(tslint_lib.report()));
 }
 
 module.exports.eslint = function(options) {
@@ -130,7 +131,7 @@ module.exports.build = function(options) {
 
   task('build', () =>
     mergeStream(
-      options.tsSrcs.pipe(typescript(tsProject)),
+      options.tsSrcs.pipe(tsProject()),
       options.dataSrcs
     ).pipe(gulp.dest('lib'))
   );

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "depcheck": "^0.6.3",
+    "depcheck": "^0.6.0",
     "fs-extra": "^2.0.0",
-    "gulp-eslint": "^3.0.1",
-    "gulp-mocha": "^3.0.1",
-    "gulp-tslint": "^7.1.0",
-    "gulp-typescript": "^3.1.4",
+    "gulp-eslint": "^3.0.0",
+    "gulp-mocha": "^3.0.0",
+    "gulp-tslint": "^7.0.0",
+    "gulp-typescript": "^3.0.0",
     "gulp-typings": "^2.0.0",
     "merge-stream": "^1.0.0",
-    "run-sequence": "^1.2.0",
-    "tslint": "^4.1.1"
+    "run-sequence": "^1.0.0",
+    "tslint": "^4.0.0"
   },
   "peerDependencies": {
     "gulp": "^3.9.1"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "depcheck": "^0.6.3",
-    "fs-extra": "^0.30.0",
-    "gulp-eslint": "^2.0.0",
-    "gulp-mocha": "^2.2.0",
-    "gulp-tslint": "^5.0.0",
-    "gulp-typescript": "^2.13.4",
+    "fs-extra": "^2.0.0",
+    "gulp-eslint": "^3.0.1",
+    "gulp-mocha": "^3.0.1",
+    "gulp-tslint": "^7.1.0",
+    "gulp-typescript": "^3.1.4",
     "gulp-typings": "^2.0.0",
     "merge-stream": "^1.0.0",
     "run-sequence": "^1.2.0",
@@ -31,7 +31,8 @@
     "gulp": "^3.9.1"
   },
   "devDependencies": {
+    "clang-format": "1.0.46",
     "gulp": "^3.9.1",
-    "clang-format": "=1.0.45"
+    "typescript": "^2.2.0"
   }
 }


### PR DESCRIPTION
Gets rid of all deprecation warnings, save those on gulp which seem unavoidable for now.