### PR TITLE
Update versions of dependencies, drop the very old `typings` tool.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,22 @@
 {
   "extends": "eslint:recommended",
-  "ecmaVersion": 6,
   "env": {
     "mocha": true,
     "node": true,
     "es6": true
   },
   "rules": {
-    "comma-dangle": [2, "always-multiline"],
-    "no-unused-vars": [2, { "vars": "all", "args": "none" }],
+    "comma-dangle": [
+      2,
+      "always-multiline"
+    ],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "args": "none"
+      }
+    ],
     "no-console": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,6 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-
-# node-waf configuration
-.lock-wscript
-
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
@@ -31,3 +25,5 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+package-lock.json

--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -15,7 +15,6 @@ const gulp = require('gulp');
 const mocha = require('gulp-mocha');
 const tslint_lib = require('gulp-tslint');
 const typescript = require('gulp-typescript');
-const typings = require('gulp-typings');
 const mergeStream = require('merge-stream');
 const path = require('path');
 const runSequence = require('run-sequence');
@@ -30,11 +29,7 @@ function task(name, deps, impl) {
 }
 
 module.exports.init = function() {
-  task('init', () => {
-    if (fs.existsSync('./typings.json')) {
-      gulp.src('./typings.json').pipe(typings())
-    }
-  });
+  task('init', () => {});
 }
 
 module.exports.depcheck = function depcheck(options) {
@@ -138,7 +133,7 @@ module.exports.build = function(options) {
 }
 
 module.exports.clean = function(options) {
-  const defaultOptions = {buildArtifacts: ['lib/', 'typings/']};
+  const defaultOptions = {buildArtifacts: ['lib/']};
   options = Object.assign({}, defaultOptions, options);
 
   task('clean', () => {

--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -28,10 +28,6 @@ function task(name, deps, impl) {
   gulp.task(name, deps, impl);
 }
 
-module.exports.init = function() {
-  task('init', () => {});
-}
-
 module.exports.depcheck = function depcheck(options) {
   const depcheck_lib = require('depcheck');
   const defaultOptions = {stickyDeps: new Set()};
@@ -159,7 +155,7 @@ module.exports.test = function(options) {
   module.exports.buildAll(options);
 
   task('test', ['build'], () =>
-    gulp.src('test/**/*_test.js', {read: false})
+    gulp.src(['test/**/*_test.js', 'src/test/**/*_test.js'], {read: false})
         .pipe(mocha({
           ui: 'tdd',
           reporter: 'spec',

--- a/package.json
+++ b/package.json
@@ -10,22 +10,21 @@
     "init": "gulp init",
     "build": "gulp build",
     "test": "gulp test",
-    "prepublish": "gulp build-all",
+    "prepublishOnly": "gulp build-all",
     "format": "find src/ test/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"
   },
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
     "depcheck": "^0.6.0",
-    "fs-extra": "^2.0.0",
-    "gulp-eslint": "^3.0.0",
-    "gulp-mocha": "^3.0.0",
-    "gulp-tslint": "^7.0.0",
+    "fs-extra": "^3.0.0",
+    "gulp-eslint": "^4.0.0",
+    "gulp-mocha": "^4.0.0",
+    "gulp-tslint": "^8.0.0",
     "gulp-typescript": "^3.0.0",
-    "gulp-typings": "^2.0.0",
     "merge-stream": "^1.0.0",
     "run-sequence": "^1.0.0",
-    "tslint": "^4.0.0"
+    "tslint": "^5.0.0"
   },
   "peerDependencies": {
     "gulp": "^3.9.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strictNullChecks": true,
     "removeComments": false,
     "preserveConstEnums": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "strict": true,
     "lib": [
       "es2017"
     ],


### PR DESCRIPTION
This is a major breaking change, so will go out as @Polymer/tools-common@2.0.0